### PR TITLE
Rules for explorer.exe

### DIFF
--- a/1_process_creation/include_explorer.xml
+++ b/1_process_creation/include_explorer.xml
@@ -3,6 +3,8 @@
     <RuleGroup name="" groupRelation="or">
       <ProcessCreate onmatch="include">
         <ParentCommandLine name="technique_id=T1204,technique_name=User Execution" condition="is">C:\Windows\explorer.exe</ParentCommandLine>
+        <ParentCommandLine name="technique_id=T1204,technique_name=User Execution" condition="is">C:\Windows\SysWOW64\explorer.exe</ParentCommandLine>
+        <Image name="New Explorer Process Creation" condition="is">explorer.exe</Image>
       </ProcessCreate>
     </RuleGroup>
   </EventFiltering>

--- a/sysmonconfig.xml
+++ b/sysmonconfig.xml
@@ -29,6 +29,8 @@
         <CommandLine name="technique_id=T1027,technique_name=Obfuscated Files or Information" condition="contains">ˆ</CommandLine>
         <CommandLine name="technique_id=T1027,technique_name=Obfuscated Files or Information" condition="contains">../../</CommandLine>
         <ParentCommandLine name="technique_id=T1204,technique_name=User Execution" condition="is">C:\Windows\explorer.exe</ParentCommandLine>
+        <ParentCommandLine name="technique_id=T1204,technique_name=User Execution" condition="is">C:\Windows\SysWOW64\explorer.exe</ParentCommandLine>
+        <Image name="New Explorer Process Creation" condition="is">explorer.exe</Image>
         <Rule name="Fltmc" groupRelation="and">
           <OriginalFileName name="technique_id=T1054,technique_name=Indicator Blocking" condition="is">fltMC.exe</OriginalFileName>
           <CommandLine name="technique_id=T1054,technique_name=Indicator Blocking" condition="contains">unload;detach</CommandLine>


### PR DESCRIPTION
- Additional rules were added to include where a 32 bit version of explorer was a parent process
- Rule added for any new explorer.exe process being created.